### PR TITLE
Update GraphQL Query Names

### DIFF
--- a/src/gql/resolvers.ts
+++ b/src/gql/resolvers.ts
@@ -10,7 +10,7 @@ type Resolvers = InferResolvers<
 
 export const resolvers: Resolvers = {
   Query: {
-    getTodos: async (parent, args, context, info) => {
+    todosByUserId: async (_parent, args, _context, _info) => {
       if (!args.userId || typeof args.userId !== 'string') {
         throw new Error('Invalid userId provided in gql');
       }

--- a/src/gql/schema.ts
+++ b/src/gql/schema.ts
@@ -13,11 +13,11 @@ export const TodoGQL = g.type("Todo", {
 });
 
 export const queryType = g.type("Query", {
-  getTodos: g.ref(() => TodoGQL).list()
+  todosByUserId: g.ref(() => TodoGQL).list()
     .args({
       userId: g.string().required()
     })
-    .description("Gets all the todos"),
+    .description("Gets all the todos for the provided user"),
 });
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the GraphQL query for fetching todos from getTodos to todosByUserId for improved clarity in the API.
  - Updated related descriptions to better specify that todos are fetched for a provided user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->